### PR TITLE
Fix C4244 warning for int-char conversion

### DIFF
--- a/libs/argParser/src/BasicVariable.cpp
+++ b/libs/argParser/src/BasicVariable.cpp
@@ -66,7 +66,7 @@ namespace argParser {
 	template<>
 	bool Variable<bool>::setValue(const std::string & value) {
 		std::string result = value;
-		std::transform(value.begin(), value.end(), result.begin(), ::tolower);
+		std::transform(value.begin(), value.end(), result.begin(), [](const char c) { return static_cast<char>(::tolower(c)); });
 		bool ret = true;
 		bool val;
 		if (result == "true") {


### PR DESCRIPTION
Visual Studio 2017 triggers a a warning about int-char conversion that was not there before in VS2015.
Since clockUtils' [warnings are treated as errors](https://github.com/ClockworkOrigins/clockUtils/blob/master/CMakeLists.txt#L78) this causes the build to fail:

```
         E:\workspace\vcpkgspace\buildtrees\clockutils\src\clockUtils-1.1.1\libs\argParser\src\BasicVariable.cpp(69): note: see reference to function template instantiation '_OutIt std::transform<std::_String_const_iterator<std::_String_val<std::_Simple_types<char>>>,std::_String_iterator<std::_String_val<std::_Simple_types<char>>>,int(__cdecl *)(int)>(_InIt,_InIt,_OutIt,_Fn1)' being compiled
                 with
                 [
                     _OutIt=std::_String_iterator<std::_String_val<std::_Simple_types<char>>>,
                     _InIt=std::_String_const_iterator<std::_String_val<std::_Simple_types<char>>>,
                     _Fn1=int (__cdecl *)(int)
                 ]
     5>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.10.25010\include\algorithm(946): warning C4244: '=': conversion from 'int' to 'char', possible loss of data (compiling source file E:\workspace\vcpkgspace\buildtrees\clockutils\src\clockUtils-1.1.1\libs\argParser\src\BasicVariable.cpp) 
```

This PR fixes the warning and enables building with v141 (VS2017). 

edit: related: https://github.com/Microsoft/vcpkg/issues/677